### PR TITLE
Corrected URL for Wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                                 <p>Connect and interact with local Mozillians.</p>
                             </li>
                             <li>
-                                <h4><a href="http://wiki.mozillaindia.org/">Wiki</a></h4>
+                                <h4><a href="http://wiki.mozillaindia.org/Main_page">Wiki</a></h4>
                                 <p>Share information and read documentation about Mozilla India.</p>
                             </li>
                             <li>


### PR DESCRIPTION
Modified the URL for Wiki as http://wiki.mozillaindia.org/Main_page
Looks like there is issue with .htaccess/Rewriting due to which Error 403 is shown for the bare domain
