### PR TITLE
Add meta image for link sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,6 +236,10 @@
                                 <div class="box">
                                     <p class="title">Campus Clubs</p>
                                     <div class="box">
+                                        <p class="subtitle">GLUG MVIT, Bangalore</p>
+                                        <a href="https://blog.glugmvit.com/">Website</a>
+                                    </div>
+                                    <div class="box">
                                             <p class="subtitle">Mozilla Campus Club BVUCOE, Pune</p>
                                             <a href="https://www.facebook.com/mozilacampusclubbvucoep/">Facebook</a>
                                     </div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
         <title>Mozilla India</title>
         <meta name="description" content="Mozilla India community homepage">
+        <meta name="og:image" content="img/favicon.ico"/>
 
         <link rel="shortcut icon" href="img/favicon.ico">
         <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/zilla-slab.css">

--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
                                             <p class="subtitle">Mozilla Karnataka (BLR)</p>
                                             <a href="https://t.me/joinchat/AFfAPD1xS9_WEiXjDfkYGA">Telegram</a>
                                             <a href="https://twitter.com/MozKarnataka">Twitter</a>
+                                            <a href="https://www.meetup.com/mozilla_bangalore/">Meetup</a>
                                     </div>
                                     <div class="box">
                                         <p class="subtitle">Mozilla Kerala</p>


### PR DESCRIPTION
The link for the website (https://mozillaindia.org/), when shared somewhere (eg. WhatsApp) doesn't display any image. I've added a meta image tag to show the favicon when the website link is shared.

WhatsApp screenshot:
![Selection_029](https://user-images.githubusercontent.com/29686866/57577987-bc0bf380-74a0-11e9-948c-5ead1a573ece.png)
