### PR TITLE
Fix Site overflow and Align Groups Horizontally. Fix #136,138

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,14 +22,12 @@
                 <a class="navbar-item" href="https://mozillaindia.org">
                     <img src="/img/mozilla-wordmark.svg" width="112" height="32" alt="Mozilla India"><span id="mozilla-india-wordmark"> india &nbsp;</span>
                 </a>
-
                 <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
                 </a>
             </div>
-
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-start">
                     <a class="navbar-item" href="https://blog.mozillaindia.org">
@@ -44,9 +42,7 @@
                     <a class="navbar-item" href=" https://activate.mozilla.community/">
                         Activate
                     </a>
-
                 </div>
-
             </div>
         </nav>
         <section class="section">
@@ -54,15 +50,13 @@
                 <h1 class="title">
                     Mozilla India
                 </h1>
-                <p class="subtitle">
-                    Home to the largest Mozilla community
-                </p>
+                <p class="subtitle">Home to the largest Mozilla community</p>
             </div>
         </section>
-        <section class="container">
-            <div class="notification is-link has-text-centered">We’re building a better Internet</div>
-            <div class="tile is-ancestor">
-                <div class="tile is-vertical">
+        <section class="section">
+            <div class="container">
+                <div class="notification is-link has-text-centered">We’re building a better Internet</div>
+                <div class="tile is-ancestor is-vertical">
                     <div class="tile is-parent">
                         <div class="tile is-child box">
                             <p class="title">Mission</p>
@@ -71,70 +65,72 @@
                             <p>Read the <a href="https://mozilla.org/about/manifesto/">Mozilla Manifesto</a> to learn even more about the values and principles that guide the pursuit of our mission.</p>
                         </div>
                     </div>
-                    <div class="tile">
-                        <div class="tile is-parent">
-                            <div class="tile is-child box">
-                                <p class="title">Communication channels</p>
-                                <ul class="iconed-list">
-                                    <li>
-                                        <span class="icon">
-                                            <img src="img/discourse.png" alt="Discourse Icon"/>
-                                        </span>
-                                        <a href="https://discourse.mozilla.org/c/india">Discourse</a> - for important topics
-                                    </li>
-                                    <li>
-                                        <span class="icon">
-                                            <img src="img/mail.jpg" alt="Mail Icon"/>
-                                        </span>
-                                        <a href="https://lists.mozilla.org/listinfo/community-india">Mailing List</a> - for restricted visibility
-                                    </li>
-                                    <li>
-                                        <span class="icon">
-                                            <img src="img/icon-telegram.svg" alt="Telegram Icon"/>
-                                        </span>
-                                        <a href="https://t.me/MozillaIN">Telegram</a> - for instant messaging
-                                    </li>
-                                    <li>
-                                        <span class="icon">
-                                            <img src="img/icon-riot.svg" alt="Matrix Icon"/>
-                                        </span>
-                                        <a href="https://matrix.to/#/!OkcrSgHxzzzLELqtai:matrix.org">Matrix</a> - for instant messaging
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div class="tile is-parent">
-                            <div class="tile is-child box">
-                                <p class="title">Social Media</p>
-                                <ul class="iconed-list">
-                                    <li>
-                                        <span class="icon" style="background: #1da1f2;">
-                                            <img src="img/twitter.png"  alt="Twitter Icon">
-                                        </span>
-                                        <a href="https://twitter.com/MozillaIN">@MozillaIN</a>
-                                    </li>
-                                    <li>
-                                        <span class="icon" style="background: #1da1f2;">
-                                            <img src="img/facebook.png" alt="Facebook Icon">
-                                        </span>
-                                        <a href="https://facebook.com/mozillaindia">mozillaindia</a>
-                                    </li>
-                                    <li>
-                                        <span class="icon">
-                                            <img src="img/icon-teach.svg" id="blog-image" alt="Blog Icon">
-                                        </span>
-                                        <a href="https://blog.mozillaindia.org">Blog</a>
-                                    </li>
-                                    <li>
-                                        <span class="icon">
-                                            <img src="img/instagram.png" alt="Instagram Icon">
-                                        </span>
-                                        <a href="https://www.instagram.com/mozillain/">mozillaindia</a>
-                                    </li>
-                                </ul>
-                            </div>
+                </div>
+                <div class="tile is-ancestor">
+                    <div class="tile is-parent">
+                        <div class="tile is-child box">
+                            <p class="title">Communication channels</p>
+                            <ul class="iconed-list">
+                                <li>
+                                    <span class="icon">
+                                        <img src="img/discourse.png" alt="Discourse Icon" />
+                                    </span>
+                                    <a href="https://discourse.mozilla.org/c/india">Discourse</a> - for important topics
+                                </li>
+                                <li>
+                                    <span class="icon">
+                                        <img src="img/mail.jpg" alt="Mail Icon" />
+                                    </span>
+                                    <a href="https://lists.mozilla.org/listinfo/community-india">Mailing List</a> - for restricted visibility
+                                </li>
+                                <li>
+                                    <span class="icon">
+                                        <img src="img/icon-telegram.svg" alt="Telegram Icon" />
+                                    </span>
+                                    <a href="https://t.me/MozillaIN">Telegram</a> - for instant messaging
+                                </li>
+                                <li>
+                                    <span class="icon">
+                                        <img src="img/icon-riot.svg" alt="Matrix Icon" />
+                                    </span>
+                                    <a href="https://matrix.to/#/!OkcrSgHxzzzLELqtai:matrix.org">Matrix</a> - for instant messaging
+                                </li>
+                            </ul>
                         </div>
                     </div>
+                    <div class="tile is-parent">
+                        <div class="tile is-child box">
+                            <p class="title">Social Media</p>
+                            <ul class="iconed-list">
+                                <li>
+                                    <span class="icon" style="background: #1da1f2;">
+                                        <img src="img/twitter.png" alt="Twitter Icon">
+                                    </span>
+                                    <a href="https://twitter.com/MozillaIN">@MozillaIN</a>
+                                </li>
+                                <li>
+                                    <span class="icon" style="background: #1da1f2;">
+                                        <img src="img/facebook.png" alt="Facebook Icon">
+                                    </span>
+                                    <a href="https://facebook.com/mozillaindia">mozillaindia</a>
+                                </li>
+                                <li>
+                                    <span class="icon">
+                                        <img src="img/icon-teach.svg" id="blog-image" alt="Blog Icon">
+                                    </span>
+                                    <a href="https://blog.mozillaindia.org">blog</a>
+                                </li>
+                                <li>
+                                    <span class="icon">
+                                        <img src="img/instagram.png" alt="Instagram Icon">
+                                    </span>
+                                    <a href="https://www.instagram.com/mozillain/">mozillaindia</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="tile is-ancestor is-vertical">
                     <div class="tile is-parent">
                         <div class="tile is-child box">
                             <p class="title has-text-centered">How do I contribute?</p>
@@ -145,129 +141,185 @@
                             <br>
                             <p>Now you may want to find other contributors near you to work together. You can attend an <a href="https://www.mozilla.org/contribute/events/">upcoming event</a>, join our communication channels, follow our social media accounts, and join many of the various sub-communities which are listed below according to your interesting</p>
                             <br>
-                            <p>Find impactful and easy ways to contribute to Mozilla in the <a href="https://activate.mozilla.community/">Activate Mozilla</a> community website. </p>
+                            <p>Find impactful and easy ways to contribute to Mozilla in the <a href="https://activate.mozilla.community/">Activate Mozilla</a> community website.</p>
                             <br>
                             <p>Would you rather just sit at a convenient place, read resources, and figure out on your own which projects to contribute to and how? Visit <a href="https://wiki.mozilla.org/Contribute"> Contribute Wiki</a> and <a href="https://whatcanidoformozilla.org/">What Can I Do For Mozilla</a>. Multiple projects are listed down at these places where you can start contributing straightaway.</p>
                             <br>
                             <p>If at any moment you find yourself stuck and unable to move forward, drop a message in any one of our communication channels and someone will surely reply. We are a bunch of friendly folks who are mindful of being inclusive in our communications and we are bound to <a href="https://www.mozilla.org/about/governance/policies/participation/">our community participation guidelines</a> which ensures that you will be treated respectfully, no matter who you are.</p>
                         </div>
                     </div>
-                    <div class="tile">
-                        <div class="tile is-parent">
-                            <div class="tile is-child">
-                                <div class="box">
+                </div>
+                <div class="tile is-ancestor is-vertical">
+                    <div class="tile is-parent">
+                        <div class="tile is-child box">
+                            <div class="tile is-ancestor is-vertical">
+                                <div class="tile is-parent">
                                     <p class="title">Regional groups</p>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Delhi</p>
-                                        <a href="https://t.me/mozilladelhi">Telegram</a>
-                                        <a href="https://twitter.com/mozilladelhincr">Twitter</a>
+                                </div>
+                                <div class="tile">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Delhi</p>
+                                            <a href="https://t.me/mozilladelhi">Telegram</a>
+                                            <a href="https://twitter.com/mozilladelhincr">Twitter</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Mozilla Gujarat</p>
                                             <a href="http://mozillagujarat.org">Website</a>
                                             <a href="https://t.me/joinchat/CpXrs0J9FOfBVAB4TTEzAw">Telegram</a>
                                             <a href="https://github.com/mozguj">GitHub</a>
                                             <a href="https://twitter.com/mozguj">Twitter</a>
                                             <a href="https://www.instagram.com/mozguj/">Instagram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Hyderabad</p>
-                                        <a href="https://t.me/MozHyderabad">Telegram</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Hyderabad</p>
+                                            <a href="https://t.me/MozHyderabad">Telegram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
+                                </div>
+                                <div class="tile">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Mozilla Karnataka (BLR)</p>
                                             <a href="https://t.me/joinchat/AFfAPD1xS9_WEiXjDfkYGA">Telegram</a>
                                             <a href="https://twitter.com/MozKarnataka">Twitter</a>
                                             <a href="https://www.meetup.com/mozilla_bangalore/">Meetup</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Kerala</p>
-                                        <a href="https://mozillakerala.com/">Website</a>
-                                        <a href="https://t.me/mozilla_kerala">Telegram</a>
-                                        <a href="https://github.com/MozillaKerala">GitHub</a>
-                                        <a href="https://twitter.com/MozillaKerala">Twitter</a>
-                                        <a href="https://www.instagram.com/mozillakerala/">Instagram</a>
-                                        
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Kerala</p>
+                                            <a href="https://mozillakerala.com/">Website</a>
+                                            <a href="https://t.me/mozilla_kerala">Telegram</a>
+                                            <a href="https://github.com/MozillaKerala">GitHub</a>
+                                            <a href="https://twitter.com/MozillaKerala">Twitter</a>
+                                            <a href="https://www.instagram.com/mozillakerala/">Instagram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Nashik</p>
-                                        <a href="https://t.me/MozillaNashik">Telegram</a>
-                                        <a href="https://twitter.com/mozillanashik">Twitter</a>
-                                        <a href="https://www.instagram.com/mozillanashik/">Instagram</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Nashik</p>
+                                            <a href="https://t.me/MozillaNashik">Telegram</a>
+                                            <a href="https://twitter.com/mozillanashik">Twitter</a>
+                                            <a href="https://www.instagram.com/mozillanashik/">Instagram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Pune</p>
-                                        <a href="https://t.me/joinchat/AAAAAD7Sg38JxPvt489eoA">Telegram</a>
-                                        <a href="https://www.facebook.com/mozPune/">Facebook</a>
-                                        <a href="https://twitter.com/mozpune">Twitter</a>
-                                        <a href="https://www.meetup.com/Pune-Mozilla-Meetup/">Meetup</a>
+                                </div>
+                                <div class="tile">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Pune</p>
+                                            <a href="https://t.me/joinchat/AAAAAD7Sg38JxPvt489eoA">Telegram</a>
+                                            <a href="https://www.facebook.com/mozPune/">Facebook</a>
+                                            <a href="https://twitter.com/mozpune">Twitter</a>
+                                            <a href="https://www.meetup.com/Pune-Mozilla-Meetup/">Meetup</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Punjab</p>
-                                        <a href="https://www.meetup.com/MozillaPunjab/">Website</a>
-                                        <a href="https://t.me/mozillapunjab">Telegram</a>
-                                        <a href="https://github.com/MozillaPunjab">GitHub</a>
-                                        <a href="https://twitter.com/MozPunjab">Twitter</a>
-                                        <a href="https://www.facebook.com/MozillaPunjab">Facebook</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Punjab</p>
+                                            <a href="https://www.meetup.com/MozillaPunjab/">Website</a>
+                                            <a href="https://t.me/mozillapunjab">Telegram</a>
+                                            <a href="https://github.com/MozillaPunjab">GitHub</a>
+                                            <a href="https://twitter.com/MozPunjab">Twitter</a>
+                                            <a href="https://www.facebook.com/MozillaPunjab">Facebook</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Tamil Nadu</p>
-                                        <a href="https://t.me/mozillatnc">Telegram</a>
-                                        <a href="https://github.com/MozillaTN">GitHub</a>
-                                        <a href="https://twitter.com/mozillaTN">Twitter</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Tamil Nadu</p>
+                                            <a href="https://t.me/mozillatnc">Telegram</a>
+                                            <a href="https://github.com/MozillaTN">GitHub</a>
+                                            <a href="https://twitter.com/mozillaTN">Twitter</a>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="tile is-parent">
-                            <div class="tile is-child">
-                                <div class="box">
+                    </div>
+                </div>
+                <div class="tile is-ancestor">
+                    <div class="tile is-parent">
+                        <div class="tile is-child box">
+                            <div class="tile is-ancestor is-vertical">
+                                <div class="tile is-parent">
                                     <p class="title">Functional groups</p>
-                                    <div class="box">
+                                </div>
+                                <div class="tile">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Hindi Localization Group</p>
                                             <a href="https://t.me/joinchat/CEMWVhH5ueW0zSAqfma6lA">Telegram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Malayalam Localization Group</p>
                                             <a href="https://t.me/firefoxsmc">Telegram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">Mozilla Open Design</p>
-                                        <a href="https://github.com/mozilla/OpenDesign/">GitHub</a>
-                                        <a href="https://t.me/opendesign">Telegram</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">Mozilla Open Design</p>
+                                            <a href="https://github.com/mozilla/OpenDesign/">GitHub</a>
+                                            <a href="https://t.me/opendesign">Telegram</a>
+                                        </div>
                                     </div>
-
                                 </div>
                             </div>
                         </div>
-                        <div class="tile is-parent">
-                            <div class="tile is-child">
-                                <div class="box">
+                    </div>
+                </div>
+                <div class="tile is-ancestor">
+                    <div class="tile is-parent">
+                        <div class="tile is-child box">
+                            <div class="tile is-ancestor is-vertical">
+                                <div class="tile is-parent is-vertical">
                                     <p class="title">Campus Clubs</p>
-                                        A Mozilla University &amp; College Club is a group of students with a passion for technology who meet regularly to advance this mission by building and innovating on open source projects that keep the web open.To learn more about Campus Clubs, you can visit the <a href="https://campus.mozilla.community/">Mozilla Campus Club Website</a><br><br>
-                                    <div class="box">
+                                    A Mozilla University &amp; College Club is a group of students with a passion for technology who meet regularly to advance this mission by building and innovating on open source projects that keep the web open.To learn more about Campus Clubs, you can visit the <a href="https://campus.mozilla.community/">Mozilla Campus Club Website</a>
+                                </div>
+                                <div class="tile">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Mozilla Campus Club BVUCOE, Pune</p>
                                             <a href="https://www.facebook.com/mozilacampusclubbvucoep/">Facebook</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">FOSSers VAST, Kerala</p>
-                                        <a href="http://fossers.vidyaacademy.ac.in">Website</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">FOSSers VAST, Kerala</p>
+                                            <a href="http://fossers.vidyaacademy.ac.in">Website</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
-                                        <p class="subtitle">GLUG MVIT, Bangalore</p>
-                                        <a href="https://blog.glugmvit.com/">Website</a>
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
+                                            <p class="subtitle">GLUG MVIT, Bangalore</p>
+                                            <a href="https://blog.glugmvit.com/">Website</a>
+                                        </div>
                                     </div>
-                                     <div class="box">
+                                </div>
+                                <div class="tile">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Mozilla Campus Club MACE, Kerala</p>
                                             <a href="https://www.instagram.com/mozillamace/">Instagram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Mozilla Campus Club NUV, Vadodara</p>
                                             <a href="https://www.instagram.com/cybersocietynuv/">Instagram</a>
+                                        </div>
                                     </div>
-                                    <div class="box">
+                                    <div class="tile is-parent">
+                                        <div class="tile is-child box">
                                             <p class="subtitle">Mozilla Campus Club SJCET, Kerala</p>
                                             <a href="https://www.instagram.com/mozilla.sjcet/">Instagram</a>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -280,12 +332,9 @@
             <div class="content has-text-centered">
                 <p>
                     <strong>Mozilla India</strong> homepage. The source code is licensed
-                    <a href="https://www.mozilla.org/en-US/MPL/" style="color:#3F51B5">MPL</a>. The website content
-                    is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" style="color:#3F51B5">CC BY NC SA 4.0</a>.
+                    <a href="https://www.mozilla.org/en-US/MPL/" style="color:#3F51B5">MPL</a>. The website content is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" style="color:#3F51B5">CC BY NC SA 4.0</a>.
                 </p>
-                <p>
-                    Found a bug? <a href="http://github.com/mozillaindia/mozillaindia.github.io" style="color:#3F51B5">Report it or fix it</a>
-                </p>
+                <p>Found a bug? <a href="http://github.com/mozillaindia/mozillaindia.github.io" style="color:#3F51B5">Report it or fix it</a></p>
             </div>
         </footer>
         <script src="/js/main.js" type="text/javascript"></script>


### PR DESCRIPTION
Fixes #136  & #138 <!-- If you are fixing an issue, provide the issue number -->

**Changes**: 
<!-- Prodvide a small description of the changes made in your Pull Request -->
- Restructured section, containers and tiles to fix overflow.
- Aligned the groups horizontally.

**Screenshots for the change**: 
<!-- If you are making some changes, it is a good idea to share screenshots or links -->

_Views on Different Devices:_ https://imgur.com/a/idZOAEb

A side-effect of these changes is that the gap between Mozilla India (Hero text) and the _We're building a better Internet_ increased due to them being in different sections (Earlier section was incorrectly implemented). Thus, both have 48px of padding on top & bottom.
**Older View**
![image](https://user-images.githubusercontent.com/22113778/59526872-a81c3d00-8ef7-11e9-8e8e-a07cdcc7f37b.png)

**New View**
![image](https://user-images.githubusercontent.com/22113778/59526895-b5d1c280-8ef7-11e9-9b54-856ac99806d4.png)
