### PR TITLE
Remove `bg-sand.png` from background stack

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,6 +1,6 @@
 body {
-  background:#f5f1e8 url("/img/bg-gradient-sand.png") repeat-x;
-  background:url("../images/bg-gradient-sand.png") repeat-x,url("/img/bg-sand.png") repeat,#f5f1e8;
+  background: #f5f1e8 url('/img/bg-gradient-sand.png') repeat-x;
+  background: url('../images/bg-gradient-sand.png') repeat-x, #f5f1e8;
   font-family: 'Fira Sans', 'Open Sans', sans-serif !important;
 }
 
@@ -19,7 +19,7 @@ body {
 }
 
 .iconed-list .icon img {
-  max-height:16px;
+  max-height: 16px;
 }
 
 .iconed-list .icon img#blog-image {


### PR DESCRIPTION
The code was introduced in https://github.com/MozillaIndia/mozillaindia.github.io/commit/df89e6264621567d3f379a1d29e153bb5123fd46 but the file was not committed with it, which led to error 404. The code is not required and should be removed.

Fixes issue : https://github.com/MozillaIndia/mozillaindia.github.io/issues/166