### PR TITLE
Enable Regional Meetup links and fix footer whitespace

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -9,7 +9,7 @@ const Footer = () =>(
     <footer className="footer">
             <div className="content has-text-centered">
                 <p>
-                    <strong>Mozilla India</strong> homepage. The source code is licensed
+                    <strong>Mozilla India</strong> homepage. The source code is licensed 
                     <Link href="https://www.mozilla.org/en-US/MPL/">MPL</Link>. The website content is licensed <Link href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</Link>.
                 </p>
                 <p>Found a bug? <Link href="http://github.com/mozillaindia/mozillaindia.github.io">Report it or fix it</Link></p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -269,6 +269,7 @@ export const query = graphql`
           twitter
           telegram
           instagram
+          meetup
           facebook
           github
         }


### PR DESCRIPTION
Fixes #178 

**Changes**: 
1. Enable meetup links for regional groups.
2. Fix whitespace before MPL in the footer text.